### PR TITLE
STYLE: Prefer C++11 type alias over typedef.

### DIFF
--- a/include/itkFourierStripeArtifactImageFilter.h
+++ b/include/itkFourierStripeArtifactImageFilter.h
@@ -49,14 +49,14 @@ template< typename TImage >
 class FourierStripeArtifactImageFilter: public ImageToImageFilter< TImage, TImage >
 {
 public:
-  typedef TImage                        ImageType;
-  typedef typename ImageType::PixelType PixelType;
+  using ImageType = TImage;
+  using PixelType = typename ImageType::PixelType;
 
-  /** Standard class typedefs. */
-  typedef FourierStripeArtifactImageFilter           Self;
-  typedef ImageToImageFilter< ImageType, ImageType > Superclass;
-  typedef SmartPointer< Self >                       Pointer;
-  typedef SmartPointer< const Self >                 ConstPointer;
+  /** Standard class type alias. */
+  using Self = FourierStripeArtifactImageFilter;
+  using Superclass = ImageToImageFilter< ImageType, ImageType >;
+  using Pointer = SmartPointer< Self >;
+  using ConstPointer = SmartPointer< const Self >;
 
   itkStaticConstMacro( ImageDimension, unsigned int, ImageType::ImageDimension );
 
@@ -89,7 +89,7 @@ protected:
 
   void BeforeThreadedGenerateData() override;
 
-  typedef typename ImageType::RegionType OutputRegionType;
+  using OutputRegionType = typename ImageType::RegionType;
   void DynamicThreadedGenerateData( const OutputRegionType & outputRegion ) override;
 
   void AfterThreadedGenerateData() override;
@@ -99,13 +99,13 @@ protected:
 private:
   ITK_DISALLOW_COPY_AND_ASSIGN(FourierStripeArtifactImageFilter);
 
-  typedef ForwardFFTImageFilter< ImageType > ForwardFFTFilterType;
+  using ForwardFFTFilterType = ForwardFFTImageFilter< ImageType >;
   typename ForwardFFTFilterType::Pointer m_ForwardFFTFilter;
 
-  typedef typename ForwardFFTFilterType::OutputImageType ComplexImageType;
+  using ComplexImageType = typename ForwardFFTFilterType::OutputImageType;
   typename ComplexImageType::Pointer m_ComplexImage;
 
-  typedef InverseFFTImageFilter< ComplexImageType > InverseFFTFilterType;
+  using InverseFFTFilterType = InverseFFTImageFilter< ComplexImageType >;
   typename InverseFFTFilterType::Pointer m_InverseFFTFilter;
 
   unsigned int m_Direction;

--- a/include/itkFourierStripeArtifactImageFilter.hxx
+++ b/include/itkFourierStripeArtifactImageFilter.hxx
@@ -83,8 +83,8 @@ void
 FourierStripeArtifactImageFilter< TImage >
 ::DynamicThreadedGenerateData( const OutputRegionType & outputRegion )
 {
-  typedef typename NumericTraits< typename ImageType::PixelType >::FloatType FloatType;
-  typedef GaussianOperator< FloatType, ImageDimension > GaussianOperatorType;
+  using FloatType = typename NumericTraits< typename ImageType::PixelType >::FloatType;
+  using GaussianOperatorType = GaussianOperator< FloatType, ImageDimension >;
 
   const unsigned int direction = this->GetDirection();
 
@@ -122,7 +122,7 @@ FourierStripeArtifactImageFilter< TImage >
   ImageLinearIteratorWithIndex< ComplexImageType > complexIt( this->m_ComplexImage, filterRegion );
   complexIt.SetDirection( direction );
 
-  typedef std::vector< FloatType > CoefficientVectorType;
+  using CoefficientVectorType = std::vector< FloatType >;
   const size_t gaussianRadius = gaussianOperator.GetRadius( direction );
   const size_t gaussianSize = gaussianOperator.GetSize( direction );
   const size_t gaussianRightSize = gaussianRadius + 1;

--- a/test/itkFourierStripeArtifactImageFilterTest.cxx
+++ b/test/itkFourierStripeArtifactImageFilterTest.cxx
@@ -36,18 +36,18 @@ int itkFourierStripeArtifactImageFilterTest( int argc, char * argv[] )
   const char * outputImageFileName = argv[2];
 
   const unsigned int                         Dimension = 2;
-  typedef float                              PixelType;
-  typedef itk::Image< PixelType, Dimension > ImageType;
+  using PixelType = float;
+  using ImageType = itk::Image< PixelType, Dimension >;
 
-  typedef itk::ImageFileReader< ImageType > ReaderType;
+  using ReaderType = itk::ImageFileReader< ImageType >;
   ReaderType::Pointer reader = ReaderType::New();
   reader->SetFileName( inputImageFileName );
 
-  typedef itk::FFTPadImageFilter< ImageType > PadFilterType;
+  using PadFilterType = itk::FFTPadImageFilter< ImageType >;
   PadFilterType::Pointer padFilter = PadFilterType::New();
   padFilter->SetInput( reader->GetOutput() );
 
-  typedef itk::FourierStripeArtifactImageFilter< ImageType > FilterType;
+  using FilterType = itk::FourierStripeArtifactImageFilter< ImageType >;
   FilterType::Pointer filter = FilterType::New();
 
   filter->SetInput( padFilter->GetOutput() );
@@ -64,7 +64,7 @@ int itkFourierStripeArtifactImageFilterTest( int argc, char * argv[] )
   filter->SetStartFrequency( startFrequency );
   TEST_SET_GET_VALUE( startFrequency, filter->GetStartFrequency() );
 
-  typedef itk::ImageFileWriter< ImageType > WriterType;
+  using WriterType = itk::ImageFileWriter< ImageType >;
   WriterType::Pointer writer = WriterType::New();
   writer->SetFileName( outputImageFileName );
   writer->SetInput( filter->GetOutput() );


### PR DESCRIPTION
Prefer C++11 type alias over typedef for the reasons stated here:
http://review.source.kitware.com/#/c/23103/