### PR TITLE
BUG: Bump version to test twine fix

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "scikit_build_core.build"
 
 [project]
 name = "itk-ringartifact"
-version = "2.0.0"
+version = "2.0.1"
 description = "ITK filters to reduce stripe artifacts or ring artifacts common in X-ray computed tomography, focused ion beam images, etc."
 readme = "README.rst"
 license = {file = "LICENSE"}


### PR DESCRIPTION
2.0.0 tagged deploy failed due to: https://github.com/pypa/twine/issues/977